### PR TITLE
nokogiri definitions for ubuntu 14.10

### DIFF
--- a/orocos.osdeps-ruby19
+++ b/orocos.osdeps-ruby19
@@ -1,7 +1,11 @@
 nokogiri:
     ubuntu:
-        '12.04,12.10,13.04,13.10,14.04,14.10':
+        '12.04,12.10,13.04,13.10,14.04':
             - ruby-nokogiri
+        default:
+          - gem: nokogiri
+          - osdep: libxml2
+          - osdep: libxslt
     default:
         - gem: nokogiri
         - osdep: libxml2

--- a/orocos.osdeps-ruby20
+++ b/orocos.osdeps-ruby20
@@ -2,7 +2,11 @@ nokogiri:
     debian:
         jessie,sid: ruby-nokogiri
     ubuntu:
-        '14.04,14.10': ruby-nokogiri
+        '14.04': ruby-nokogiri
+         default:
+          - gem: nokogiri
+          - osdep: libxml2
+          - osdep: libxslt
     fedora:
         '20': rubygem-nokogiri
     default:

--- a/orocos.osdeps-ruby21
+++ b/orocos.osdeps-ruby21
@@ -5,7 +5,12 @@ nokogiri:
     fedora:
         '20': rubygem-nokogiri
     ubuntu:
-        '14.04,14.10': ruby-nokogiri
+        '14.04': ruby-nokogiri
+        default:
+          - gem: nokogiri
+          - osdep: libxml2
+          - osdep: libxslt
+        
     default:
         - gem: nokogiri
         - osdep: libxml2


### PR DESCRIPTION
Adds a default to use the gem versions of nokogiri for ubuntu 14.10 (and future versions)

Without this, no nokogiri osdep is defined at all for unmentioned ubuntu versions.

This PR used the gem version because the OS package seems to be broken, as it cannot be included and fails with "cannot require nokogiri/nokogiri" (see example below)

To me it looks like a file of nokogiri relies on a nokogiri subfolder with the same name, which the lib version doesn't have ("vendor_ruby" instead), or the issue is from using 1.9.1 and the package is for 2.1. 

Nevertheless using the gem works fine.

/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- nokogiri/nokogiri (LoadError)
        from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
        from /usr/lib/ruby/vendor_ruby/nokogiri.rb:29:in `rescue in <top (required)>'
        from /usr/lib/ruby/vendor_ruby/nokogiri.rb:25:in`<top (required)>'
        from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
        from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in`require'
