### PR TITLE
Add arch linux readline osdep

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -52,6 +52,7 @@ libreadline:
     fedora: readline-devel
     opensuse: readline-devel
     macos-brew: readline
+    arch: readline
 
 lua-dev:
     debian,ubuntu: liblua5.1-0-dev


### PR DESCRIPTION
The readline lib is called "readline" on Arch Linux.