### PR TITLE
integrate typelib's castxml importer

### DIFF
--- a/manifests/castxml.xml
+++ b/manifests/castxml.xml
@@ -1,0 +1,16 @@
+<package>
+    <description brief="a C-family abstract syntax tree XML output tool.">
+    </description>
+    <license>Apache License, Version 2.0</license>
+    <author>Kitware</author>
+
+    <url>https://github.com/CastXML/CastXML</url>
+
+    <rosdep name="cmake" />
+    <rosdep name="libclang-castxml" />
+    <rosdep name="zlib" />
+    <rosdep name="libedit" />
+    <tags>stable</tags>
+</package>
+
+

--- a/orocos.autobuild
+++ b/orocos.autobuild
@@ -72,10 +72,17 @@ end
 remove_from_default 'utilmm'
 cmake_package 'typelib' do |pkg|
     pkg.define "RUBY_EXECUTABLE", Autoproj::CmdLine.ruby_executable
+
+    cxx_loader =
+        if Autoproj.respond_to?(:workspace)
+	    Autoproj.workspace.env['TYPELIB_CXX_LOADER']
+        else ENV['TYPELIB_CXX_LOADER']
+        end
+
     # Enable the clang importer by adding the following in autoproj/init.rb
     #
     #   Autoproj.env_set 'TYPELIB_CXX_LOADER', 'clang'
-    pkg.define 'BUILD_CLANG_TLB_IMPORTER', (ENV['TYPELIB_CXX_LOADER'] == 'clang')
+    pkg.define 'BUILD_CLANG_TLB_IMPORTER', (cxx_loader == 'clang')
     pkg.post_import do
         # remove_dependency is post-1.9.0
         m = if pkg.respond_to?(:remove_dependency)
@@ -83,13 +90,23 @@ cmake_package 'typelib' do |pkg|
             else pkg.os_packages.method(:delete)
             end
         
-        if ENV['TYPELIB_CXX_LOADER'] == 'clang'
+        if cxx_loader == 'clang'
+	    pkg.message "%s: using the clang importer"
             m.call 'gccxml'
+            m.call 'castxml'
+        elsif cxx_loader == 'castxml'
+	    pkg.message "%s: using the castxml importer"
+            m.call 'gccxml'
+            m.call 'clang-3.4'
         else
+	    pkg.message "%s: using the gccxml importer"
+            m.call 'castxml'
             m.call 'clang-3.4'
         end
     end
 end
+cmake_package 'castxml'
+remove_from_default 'castxml'
 cmake_package 'rtt_typelib'
 ruby_package 'orogen'
 cmake_package 'stdint_typekit'

--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -167,7 +167,7 @@ clang-3.4:
 
 libclang-castxml:
     ubuntu:
-        '14.04,14.10': [libclang-3.5-dev, llvm-3.5-dev]
+        '14.04,14.10': nonexistent
         '15.04': [libclang-3.6-dev, llvm-3.6-dev]
         '15.10': [libclang-3.7-dev, llvm-3.7-dev]
         default: [libclang-3.7-dev, llvm-3.7-dev]

--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -165,4 +165,18 @@ hoe: gem
 clang-3.4:
     debian, ubuntu: [llvm-3.4, clang-3.4, libclang-3.4-dev]
 
+libclang-castxml:
+    ubuntu:
+        '14.04,14.10': [libclang-3.5-dev, llvm-3.5-dev]
+        '15.04': [libclang-3.6-dev, llvm-3.6-dev]
+        '15.10': [libclang-3.7-dev, llvm-3.7-dev]
+        default: [libclang-3.7-dev, llvm-3.7-dev]
+
+zlib:
+    ubuntu,debian: zlib1g-dev
+
+libedit:
+    ubuntu,debian: libedit-dev
+    
+
 bundler: gem

--- a/source.yml
+++ b/source.yml
@@ -8,3 +8,6 @@ version_control:
         github: rock-core/tools-metaruby
         branch: master
 
+    - castxml:
+        github: CastXML/CastXML
+        branch: master


### PR DESCRIPTION
This adds optional integration of typelib's castxml importer (which is made available by https://github.com/orocos-toolchain/typelib/pull/66). This PR can be merged even without the typelib's PR merged as the importer must still be explicitely selected.