### PR TITLE
remove usage of APIs deprecated in autoproj 2.0 in a 1.x-compatible way

### DIFF
--- a/orocos.autobuild
+++ b/orocos.autobuild
@@ -15,16 +15,16 @@ cmake_package 'rtt' do |pkg|
     pkg.doc_dir = File.join('doc', 'api', 'html')
     pkg.with_doc('docapi')
 
-    env_set 'OROCOS_TARGET', user_config('rtt_target')
-    env_add 'CMAKE_PREFIX_PATH', pkg.prefix
-
-    target = user_config('rtt_target')
+    
+    target = Autoproj.config.get('rtt_target')
+    env_set 'OROCOS_TARGET', target
     pkg.define "OROCOS_TARGET", target
+
+    env_add 'CMAKE_PREFIX_PATH', pkg.prefix
 
     # Used by the oroGen handler
     pkg.provides "pkgconfig/orocos-rtt-#{target}"
-
-    Autoproj.user_config('rtt_corba_implementation')
+    Autoproj.config.get('rtt_corba_implementation')
 
 
     # Disable building the test suite because it needs a lot of time and memory
@@ -34,7 +34,7 @@ cmake_package 'rtt' do |pkg|
     # to autoproj/overrides.rb
     pkg.define "BUILD_TESTING", "OFF"
 
-    corba = user_config('rtt_corba_implementation')
+    corba = Autoproj.config.get('rtt_corba_implementation')
     if corba == 'none'
         Autobuild::Orogen.corba = false
         pkg.define "ENABLE_CORBA", "OFF"
@@ -52,7 +52,7 @@ cmake_package 'ocl' do |pkg|
     pkg.doc_dir = File.join('doc', 'api', 'html')
     pkg.with_doc('docapi')
 
-    target = user_config('rtt_target')
+    target = Autoproj.config.get('rtt_target')
     pkg.define "OROCOS_TARGET", target
 end
 


### PR DESCRIPTION
This uses API that was already present in 1.x, but for which no
deprecation warnings had been issued. 2.x will be pretty verbose
about these, so change the autobuild code to either use the new
APIs, or be compatible with both 1.x and 2.0