### PR TITLE
define ruby-dev to install ruby development packages

### DIFF
--- a/orocos.osdeps-ruby19
+++ b/orocos.osdeps-ruby19
@@ -11,3 +11,9 @@ nokogiri:
         - osdep: libxml2
         - osdep: libxslt
 
+
+ruby-dev:
+    ubuntu:
+        '14.04': ruby1.9.1-dev
+        default: ignore
+    default: ignore

--- a/orocos.osdeps-ruby20
+++ b/orocos.osdeps-ruby20
@@ -14,3 +14,8 @@ nokogiri:
         - osdep: libxml2
         - osdep: libxslt
 
+ruby-dev:
+    ubuntu:
+        '14.04,14.10,15.04': ruby2.0-dev
+        default: ignore
+    default: ignore

--- a/orocos.osdeps-ruby21
+++ b/orocos.osdeps-ruby21
@@ -17,3 +17,9 @@ nokogiri:
         - osdep: libxslt
 
 
+
+ruby-dev:
+    ubuntu:
+        '15.10': ruby2.1-dev
+        default: ignore
+    default: ignore

--- a/orocos.osdeps-ruby22
+++ b/orocos.osdeps-ruby22
@@ -1,0 +1,6 @@
+ruby-dev:
+    ubuntu:
+        '15.10': ruby2.2-dev
+        default: ignore
+    default: ignore
+

--- a/orocos.osdeps-ruby23
+++ b/orocos.osdeps-ruby23
@@ -1,0 +1,5 @@
+ruby-dev:
+    ubuntu:
+        '14.04,14.10,15.04,15.10': ignore
+        default: ruby2.3-dev
+    default: ignore


### PR DESCRIPTION
They were installed by autoproj v1 because utilrb needed them.
Now, utilrb does not need them anymore, so autoproj itself won't
install them. Install them explicitely instead.

Relevant package-level patches (to the dependencies) will follow
once this is merged