### PR TITLE
add an osdep for pkg-config

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -1,3 +1,6 @@
+pkg-config:
+    default: pkg-config
+
 boost:
     debian,ubuntu:
         - libboost-dev


### PR DESCRIPTION
This is required for typelib. Bootstrapping only the toolchain on master with autoproj v1 currently fails because of this.

**NOTE**: must be backported to toolchain-2.8