### PR TITLE
added debian entry for castxml

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -172,6 +172,8 @@ castxml:
     ubuntu:
         '14.04,14.10,15.04,15.10': nonexistent
         default: castxml
+    debian:
+        default: castxml
 
 libclang-castxml:
     ubuntu:

--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -179,6 +179,7 @@ libclang-castxml:
         '15.04': [libclang-3.6-dev, llvm-3.6-dev]
         '15.10': [libclang-3.7-dev, llvm-3.7-dev]
         default: [libclang-3.7-dev, llvm-3.7-dev]
+    debian: ignore
 
 zlib:
     ubuntu,debian: zlib1g-dev


### PR DESCRIPTION
if not present, autoproj fails to resolve the dependency when https://github.com/orocos-toolchain/autoproj/blob/master/manifests/castxml.xml is loaded from this package