### PR TITLE
Constrain rake version to <11.0 on Ubuntu

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -120,7 +120,11 @@ rdoc:
         gem
 
 rake:
-    debian,ubuntu: rake
+    debian: rake
+    ubuntu: 
+      '12.04,14.04,14.10,15.04,15.10': rake
+      '16.04': 
+        gem: rake<11.0
     fedora: rubygem-rake
     default:
         gem


### PR DESCRIPTION
Building orogen led to this error on my Ubuntu16.04:

```
2019-02-13 10:56:17 +0100: running
    /usr/bin/ruby2.3 -S rake default
in directory /media/wirkus/Data/development/q-rock/tools/orogen
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000001c953a0>
/media/wirkus/Data/development/q-rock/tools/utilrb/lib/utilrb/doc/rake.rb:40:in `new'
/media/wirkus/Data/development/q-rock/tools/utilrb/lib/utilrb/doc/rake.rb:40:in `doc'
/media/wirkus/Data/development/q-rock/tools/orogen/Rakefile:71:in `<top (required)>'
```

The system got rake version `rake, version 12.3.2` installed as osdep.

Stackoverflow att https://stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11 says that since Rake 11 does not provide the `last_comment` function anymore.

This merge request as rather a hot fix, but not as real solution, since the root of the problem is the usage of old API function (don't know where this is).