### PR TITLE
fix: installation on Debian 11

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -151,7 +151,8 @@ facets:
     ubuntu: gem
     debian:
         squeeze: gem
-        default: ruby-facets
+        7,8,9,10: ruby-facets
+        default: gem
     fedora: rubygem-facets
     default:
         gem: facets


### PR DESCRIPTION
Prepackaged ruby-facets does not exist anymore, install from gem
instead