### PR TITLE
fix the syntax for debian numerical version

### DIFF
--- a/orocos.osdeps
+++ b/orocos.osdeps
@@ -151,7 +151,7 @@ facets:
     ubuntu: gem
     debian:
         squeeze: gem
-        7,8,9,10: ruby-facets
+        '7,8,9,10': ruby-facets
         default: gem
     fedora: rubygem-facets
     default:


### PR DESCRIPTION
fix the error:

`  ERROR: error in .../autoproj/remotes/orocos.toolchain/orocos.osdeps: invalid osdeps definition: found an Integer as a key in facets/debian. Don't forget to put quotes around numbers`

@doudou Hello Sylvain! Could you please check and merge it? Thank you!