### PR TITLE
Add orocos.osdeps-ruby32 for Ubuntu24.04 compatibility

### DIFF
--- a/orocos.osdeps-ruby32
+++ b/orocos.osdeps-ruby32
@@ -1,0 +1,2 @@
+ruby-dev:
+    default: ignore


### PR DESCRIPTION
Since `orocos.osdeps-ruby24` to `orocos.osdeps-ruby32` are now 6 identical files, maybe there is a better way to default to this, except for older ruby versions (if they are even still supported).