### PR TITLE
Remove `pkg.define "RUBY_EXECUTABLE"`

### DIFF
--- a/orocos.autobuild
+++ b/orocos.autobuild
@@ -69,7 +69,6 @@ cmake_package 'utilmm' do |pkg|
 end
 remove_from_default 'utilmm'
 cmake_package 'typelib' do |pkg|
-    pkg.define 'RUBY_EXECUTABLE', Autoproj::CmdLine.ruby_executable
     pkg.env_set 'TYPELIB_PLUGIN_PATH', File.join(pkg.prefix, 'lib', 'typelib')
 
     # Enable the castxml importer by adding the following in autoproj/init.rb


### PR DESCRIPTION
Related: 
* https://github.com/rock-core/base-cmake/pull/94
* https://github.com/rock-core/package_set/pull/251

As above, I have no idea, if there are systems where setting `RUBY_EXECUTABLE` actually is necessary

@doudou @planthaber 
